### PR TITLE
Fix plugin management for drink.sh installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,21 +51,22 @@ After installation, restart your terminal or type `zsh` to begin using your new 
 
 ## 🔌 Plugin System
 
-Potions includes a plugin system to extend functionality:
+Potions includes a plugin system to extend functionality. After running the
+installer, plugin management tools are placed inside `~/.potions`:
 
 ### Install Plugins
 ```bash
 # Create a plugins.txt file with your desired plugins
-echo "Rynaro/mini-rails" > plugins.txt
+echo "Rynaro/mini-rails" > ~/.potions/plugins.txt
 
 # Install plugins
-./plugins.sh install
+~/.potions/plugins.sh install
 ```
 
 ### Create Your Own Plugin
 ```bash
 # Scaffold a new plugin
-./plugins.sh create my_awesome_plugin
+~/.potions/plugins.sh create my_awesome_plugin
 ```
 
 ## 🛠️ What's Included

--- a/install.sh
+++ b/install.sh
@@ -7,6 +7,9 @@ source "$POTIONS_ROOT/packages/accessories.sh"
 update_potions() {
   log 'Sending Potions files to HOME...'
   cp -r .potions ~/
+  cp -r packages "$HOME/.potions/"
+  cp -r plugins "$HOME/.potions/"
+  cp plugins.sh "$HOME/.potions/"
 }
 
 prepare_system() {

--- a/plugins.sh
+++ b/plugins.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
-source "$(dirname "$0")/packages/accessories.sh"
 
-safe_source 'plugins/manage.sh'
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/packages/accessories.sh"
+
+safe_source "$SCRIPT_DIR/plugins/manage.sh"
 
 # Execute the manage_plugins function with provided arguments
 manage_plugins "$@"

--- a/plugins/generators.sh
+++ b/plugins/generators.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-source "$(dirname "$0")/packages/accessories.sh"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$(dirname "$SCRIPT_DIR")/packages/accessories.sh"
 
 # Function to scaffold a new plugin
 scaffold_plugin() {
@@ -11,7 +12,7 @@ scaffold_plugin() {
     exit 1
   fi
 
-  safe_source "$(dirname "$0")/plugins/scaffold_plugin.sh"
+  safe_source "$SCRIPT_DIR/scaffold_plugin.sh"
   create_plugin $plugin_name
 }
 

--- a/plugins/install.sh
+++ b/plugins/install.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-source "$(dirname "$0")/packages/accessories.sh"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$(dirname "$SCRIPT_DIR")/packages/accessories.sh"
+
+: "${PLUGINS_DIR:=$SCRIPT_DIR}"
 
 # Function to install plugins
 install_plugins() {

--- a/plugins/manage.sh
+++ b/plugins/manage.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
-PLUGINS_DIR="plugins"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGINS_DIR="$SCRIPT_DIR"
+PLUGINS_FILE="$(dirname "$SCRIPT_DIR")/plugins.txt"
 
-source "$(dirname "$0")/packages/accessories.sh"
+source "$(dirname "$SCRIPT_DIR")/packages/accessories.sh"
 
 # Main function to manage plugins
 manage_plugins() {
@@ -11,13 +13,13 @@ manage_plugins() {
 
   case $action in
     install)
-      safe_source "$(dirname "$0")/plugins/obtain.sh"
-      safe_source "$(dirname "$0")/plugins/install.sh"
+      safe_source "$SCRIPT_DIR/obtain.sh"
+      safe_source "$SCRIPT_DIR/install.sh"
       obtain_plugins
       install_plugins
       ;;
     create)
-      safe_source "$(dirname "$0")/plugins/generators.sh"
+      safe_source "$SCRIPT_DIR/generators.sh"
       manage_plugins create $plugin_name
       ;;
     *)

--- a/plugins/obtain.sh
+++ b/plugins/obtain.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-PLUGINS_DIR="plugins"
-PLUGINS_FILE="plugins.txt"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGINS_DIR="${PLUGINS_DIR:-$SCRIPT_DIR}"
+PLUGINS_FILE="${PLUGINS_FILE:-$(dirname "$SCRIPT_DIR")/plugins.txt}"
 
 # Function to parse plugins.txt and clone repositories
 obtain_plugins() {

--- a/plugins/scaffold_plugin.sh
+++ b/plugins/scaffold_plugin.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-PLUGINS_DIR="plugins"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGINS_DIR="${PLUGINS_DIR:-$SCRIPT_DIR}"
 
 # Function to create a new plugin scaffold
 create_plugin() {
@@ -16,13 +17,13 @@ create_plugin() {
   mkdir -p "$plugin_dir/packages"
 
   # Create the blank install.sh script
-  cat plugins/templates/install.sh > "$plugin_dir/install.sh"
+  cat "$SCRIPT_DIR/templates/install.sh" > "$plugin_dir/install.sh"
 
   # Create utilities.sh
-  cat plugins/utilities.sh > "$plugin_dir/utilities.sh"
+  cat "$SCRIPT_DIR/utilities.sh" > "$plugin_dir/utilities.sh"
 
   # Create a blank package1.sh script
-  cat plugins/templates/package1.sh > "$plugin_dir/packages/package1.sh"
+  cat "$SCRIPT_DIR/templates/package1.sh" > "$plugin_dir/packages/package1.sh"
 
   # Make the scripts executable
   chmod +x "$plugin_dir/install.sh"


### PR DESCRIPTION
## Summary
- ship plugin management scripts alongside dotfiles during installation
- load scripts relative to their location
- document new plugin workflow

## Testing
- `bash -n install.sh`
- `bash -n plugins.sh`
- `bash -n plugins/manage.sh`
- `bash -n plugins/obtain.sh`
- `bash -n plugins/install.sh`
- `bash -n plugins/generators.sh`
- `bash -n plugins/scaffold_plugin.sh`


------
https://chatgpt.com/codex/tasks/task_e_684c9322370c83208ccf2e4ad33abdc3