### PR TITLE
Fix: CTRL+C prompt rendering issue

### DIFF
--- a/.potions/.zshrc
+++ b/.potions/.zshrc
@@ -34,7 +34,8 @@ export PATH="$HOME/.neovim/bin:$PATH"
 export EDITOR=nvim
 
 # Git Prompt configuration
-PROMPT='%F{cyan}%n%f%F{magenta}@%f%F{red}%m%f:%b$(git_super_status) %~ %(#.#.$) '
+# Wrap git_super_status in error handling to prevent prompt rendering issues
+PROMPT='%F{cyan}%n%f%F{magenta}@%f%F{red}%m%f:%b$(git_super_status 2>/dev/null || echo "") %~ %(#.#.$) '
 
 if is_macos; then
   # macOS-specific configurations
@@ -84,6 +85,18 @@ setopt EXTENDED_HISTORY
 setopt APPEND_HISTORY
 setopt HIST_IGNORE_SPACE
 setopt HIST_REDUCE_BLANKS
+
+# Fix prompt rendering after CTRL+C (SIGINT)
+# Reset terminal state and refresh prompt after interrupt
+TRAPINT() {
+    # Reset terminal to known good state
+    [[ -t 0 ]] && stty sane 2>/dev/null
+    # Force prompt refresh if in interactive mode
+    if [[ -o interactive ]]; then
+        zle && { zle .reset-prompt 2>/dev/null || true }
+    fi
+    return 128
+}
 
 if command -v tmux &> /dev/null && [ -z "$TMUX" ]; then
   TMUX_PROFILE_NAME="potions-$$+"

--- a/.potions/tmux/tmux.conf
+++ b/.potions/tmux/tmux.conf
@@ -24,7 +24,12 @@ unbind %
 
 # Enable 256 colors
 set -g default-terminal "tmux-256color"
-set -ga terminal-overrides ",*256col*:Tc"
+
+# Fix terminal state after CTRL+C - ensures prompt renders correctly
+# focus-events helps tmux track terminal state changes
+set -g focus-events on
+# Terminal overrides: enable truecolor, fix backspace, disable application keypad mode
+set -ga terminal-overrides ",*256col*:Tc,*:kbs=\\177:smkx@:rmkx@"
 
 # Pass through Ctrl + arrow keys for word navigation in command line
 set -g xterm-keys on


### PR DESCRIPTION
This pull request focuses on improving the robustness of the terminal prompt and shell environment, especially after interrupts (like pressing CTRL+C), and enhances terminal compatibility in both Zsh and tmux configurations. The main changes are grouped into prompt reliability improvements and tmux terminal state handling.

**Prompt reliability improvements:**

* The `git_super_status` command in the Zsh prompt is now wrapped in error handling to prevent prompt rendering issues if the command fails.
* Added a `TRAPINT` function in `.zshrc` to reset the terminal state and refresh the prompt after receiving a SIGINT (CTRL+C), ensuring the prompt displays correctly after interrupts.

**Tmux terminal state handling:**

* Enabled `focus-events` in `tmux.conf` to help tmux track terminal state changes, which can improve prompt rendering after terminal focus changes or interrupts.
* Updated `terminal-overrides` in `tmux.conf` to enable truecolor, fix the backspace key, and disable application keypad mode, further ensuring correct terminal behavior and prompt rendering.