### PR TITLE
fix(termux): symlink ~/.termux/shell instead of writing the path as text

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -498,7 +498,7 @@ Termux testing runs in CI using GitHub's native ARM64 runners with the official 
 - Validates Termux-specific behaviors:
   - Platform detection (`is_termux()`)
   - Package installation via `pkg` command
-  - Shell setup via `~/.termux/shell` file
+  - Shell setup via `~/.termux/shell` symlink (Termux execs this path directly; it must be a symlink to the shell binary, not a text file)
   - Environment variables (`$PREFIX`, `termux-info`)
 
 **Why native ARM64 runners?**

--- a/packages/termux/zsh.sh
+++ b/packages/termux/zsh.sh
@@ -23,10 +23,12 @@ if [ "$SHELL" != "$(command -v zsh)" ]; then
     fi
   fi
   
-  # Write zsh path to ~/.termux/shell
-  if ! echo "$zsh_path" > "$termux_shell_file"; then
-    log "WARNING: Failed to write zsh path to $termux_shell_file"
-    log "You can manually set it by running: echo '$zsh_path' > ~/.termux/shell"
+  # Termux's login execs ~/.termux/shell directly — it must be a SYMLINK
+  # to the shell binary, not a file containing the path. Writing text here
+  # permanently locks the user out of Termux (exec: Permission denied).
+  if ! ln -sfn "$zsh_path" "$termux_shell_file"; then
+    log "WARNING: Failed to symlink $termux_shell_file -> $zsh_path"
+    log "You can manually set it by running: ln -sfn '$zsh_path' ~/.termux/shell"
   else
     log "Successfully set zsh as default shell for Termux"
     log "NOTE: You need to restart the Termux app for the change to take effect"

--- a/test.sh
+++ b/test.sh
@@ -524,21 +524,25 @@ test_termux_shell_setup() {
     return 0
   fi
 
-  # Check if ~/.termux/shell file exists (created by zsh.sh)
-  if [ -f "$HOME/.termux/shell" ]; then
-    log_success "Termux shell configuration file exists"
+  # ~/.termux/shell MUST be a symlink to the shell binary — Termux execs it
+  # directly. A regular file (even with a valid path inside) makes Termux
+  # unusable with "exec: Permission denied" on next launch.
+  if [ -L "$HOME/.termux/shell" ]; then
+    log_success "Termux shell configuration is a symlink"
     TESTS_PASSED=$((TESTS_PASSED + 1))
-    
-    # Verify it contains zsh path
-    local shell_path
-    shell_path=$(cat "$HOME/.termux/shell" 2>/dev/null || echo "")
-    if [ -n "$shell_path" ] && [ -x "$shell_path" ]; then
-      log_success "Termux shell file contains valid zsh path"
+
+    local shell_target
+    shell_target=$(readlink -f "$HOME/.termux/shell" 2>/dev/null || echo "")
+    if [ -n "$shell_target" ] && [ -x "$shell_target" ]; then
+      log_success "Termux shell symlink resolves to an executable ($shell_target)"
       TESTS_PASSED=$((TESTS_PASSED + 1))
     else
-      log_failure "Termux shell file does not contain valid zsh path"
+      log_failure "Termux shell symlink does not resolve to an executable"
       TESTS_FAILED=$((TESTS_FAILED + 1))
     fi
+  elif [ -e "$HOME/.termux/shell" ]; then
+    log_failure "Termux shell configuration exists but is not a symlink — this locks the user out of Termux"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
   else
     log_skip "Termux shell configuration not found (may be normal if zsh already default)"
     TESTS_SKIPPED=$((TESTS_SKIPPED + 1))


### PR DESCRIPTION
## Summary

- **Bug**: After installing Potions on Termux, the app becomes unusable on next launch:
  ```
  /data/data/com.termux/files/usr/bin/login: 61: exec:
    /data/data/com.termux/files/home/.termux/shell: Permission denied
  [Process completed (code 126) - press Enter]
  ```
  The only recovery is clearing Termux's app data — destroying the user's home directory.
- **Root cause**: `packages/termux/zsh.sh` wrote the zsh path as **text** into `~/.termux/shell`. Termux's `login` execs that path directly, so it must be a **symlink** to the shell binary. A text file without `+x` (and without a shebang) fails `exec` with `EACCES` on every Termux launch.
- **Fix**: Use `ln -sfn "$zsh_path" ~/.termux/shell`. The `-f` flag also self-heals already-broken installs when the installer is re-run.
- Updated `test_termux_shell_setup` to assert the symlink shape and fail loudly if `~/.termux/shell` is a regular file (the previous test endorsed the broken design — that's why CI never caught this).
- Fixed the AGENTS.md note that called the path a "file".

## Test plan

- [ ] `bash -n packages/termux/zsh.sh test.sh` (done locally — passes)
- [ ] Fresh-install test in Termux container:
  ```bash
  docker run --rm --privileged -v "$PWD:/workspace" \
    termux/termux-docker:aarch64 \
    /entrypoint.sh bash -c "cd /workspace && ./install.sh && \
      test -L ~/.termux/shell && test -x \"\$(readlink -f ~/.termux/shell)\" && echo OK"
  ```
- [ ] Recovery test — simulate the previously-broken state, then re-run installer:
  ```bash
  docker run --rm --privileged -v "$PWD:/workspace" \
    termux/termux-docker:aarch64 \
    /entrypoint.sh bash -c "mkdir -p ~/.termux && \
      echo /data/data/com.termux/files/usr/bin/zsh > ~/.termux/shell && \
      cd /workspace && ./install.sh && test -L ~/.termux/shell && echo HEALED"
  ```
- [ ] `./test.sh` inside the same container — updated `test_termux_shell_setup` passes.
- [ ] Real-device smoke: install on Termux, restart app, lands in zsh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)