### PR TITLE
ci(termux): fix shebang failure on native ARM64 runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,9 +86,6 @@ jobs:
     name: Test on Termux (native aarch64)
     runs-on: ubuntu-24.04-arm  # Native ARM64 runner - no QEMU emulation needed
     timeout-minutes: 10
-    # Allow failures while stabilizing the native ARM64 pipeline
-    # Remove this once the pipeline is confirmed stable
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
 
@@ -127,7 +124,10 @@ jobs:
               fi
               
               echo ''
-              ./test.sh --no-simulate
+              # Invoke via bash explicitly: Termux has no /bin/bash, and the
+              # docker container doesn't load termux-exec's shebang-rewriting
+              # LD_PRELOAD, so #!/bin/bash would fail with bad interpreter.
+              bash ./test.sh --no-simulate
             "
 
       - name: Test install simulation
@@ -167,7 +167,7 @@ jobs:
               
               echo ''
               echo '=== Running Install Simulation ==='
-              ./install.sh --test
+              bash ./install.sh --test
             "
 
   idempotency-test:


### PR DESCRIPTION
## Summary
- Termux test job has been failing since stand-up of the native ARM64 runner with `bash: ./test.sh: /bin/bash: bad interpreter: No such file or directory`. The job was masked by `continue-on-error: true`.
- Root cause: Termux has no `/bin/bash` — bash lives at `$PREFIX/bin/bash`. Real Termux installs work because the `termux-exec` LD_PRELOAD library rewrites the shebang at `execve` time. The `termux/termux-docker` image in CI doesn't load that LD_PRELOAD, so direct invocation via shebang lookup (`./test.sh`) fails.
- Invoke scripts as `bash ./test.sh` and `bash ./install.sh --test` inside the Termux container — no dependency on `/bin/bash` resolving.
- Drop `continue-on-error: true` from the Termux job now that the underlying issue is fixed.

## Test plan
- [ ] Termux test job goes green in this PR
- [ ] Other platforms (Ubuntu, macOS, Fedora) remain green
- [ ] Job failure now blocks merge (no `continue-on-error`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)